### PR TITLE
Accept barcode object or text field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ TAGS
 coverage
 node_modules
 reports
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage
 node_modules
 reports
 package-lock.json
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   instead `barcodeToEnvelopedCredential` should be used to produce an
   `EnvelopedVerifiableCredential` without the need for any local CBOR-LD
   configuration.
+- Accept `type` field to differentiate between scanned barcode types.
 
 ## 1.1.0 - 2025-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
   instead `barcodeToEnvelopedCredential` should be used to produce an
   `EnvelopedVerifiableCredential` without the need for any local CBOR-LD
   configuration.
-- Accept `type` field to differentiate between scanned barcode types.
+- Accept `barcode` object or `text` field.
 
 ## 1.1.0 - 2025-02-05
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,3 +3,21 @@
  */
 export const NAMESPACE = 'vcb-verifier';
 export const VC_CONTEXT_V2 = 'https://www.w3.org/ns/credentials/v2';
+
+// See https://wicg.github.io/shape-detection-api/#barcodeformat-section
+export const BARCODE_FORMATS = Object.freeze({
+  AZTEC: 'aztec',
+  CODE_128: 'code_128',
+  CODE_39: 'code_39',
+  CODE_93: 'code_93',
+  CODABAR: 'codabar',
+  DATA_MATRIX: 'data_matrix',
+  EAN_13: 'ean_13',
+  EAN_8: 'ean_8',
+  ITF: 'itf',
+  PDF417: 'pdf417',
+  QR_CODE: 'qr_code',
+  UNKNOWN: 'unknown',
+  UPC_a: 'upc_a',
+  UPC_e: 'upc_e'
+});

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -3,7 +3,6 @@
  */
 import assert from 'assert-plus';
 import {asyncHandler} from '@bedrock/express';
-import {BARCODE_FORMATS} from './constants.js';
 import {createValidateMiddleware as validate} from '@bedrock/validation';
 import {verifyBody} from '../schemas/bedrock-vcb-verifier.js';
 import {verifyVcb} from './verify.js';
@@ -15,11 +14,7 @@ export function createVerifyVcb({getVerifyOptions} = {}) {
     validate({bodySchema: verifyBody}),
     asyncHandler(async (req, res) => {
       const {text, barcode} = req.body;
-      const data = barcode?.data ?? text;
-      // default to 'qr_code' format if value is not included
-      const format = barcode?.format || BARCODE_FORMATS.QR_CODE;
-      // accept text or data and default format to qr_code
-      const result = await verifyVcb({data, format, getVerifyOptions});
+      const result = await verifyVcb({text, barcode, getVerifyOptions});
       res.json(result);
     })];
   return function verifyVcbMiddleware(req, res, next) {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -3,6 +3,7 @@
  */
 import assert from 'assert-plus';
 import {asyncHandler} from '@bedrock/express';
+import {BARCODE_FORMATS} from './constants.js';
 import {createValidateMiddleware as validate} from '@bedrock/validation';
 import {verifyBody} from '../schemas/bedrock-vcb-verifier.js';
 import {verifyVcb} from './verify.js';
@@ -13,8 +14,9 @@ export function createVerifyVcb({getVerifyOptions} = {}) {
   const mw = [
     validate({bodySchema: verifyBody}),
     asyncHandler(async (req, res) => {
-      const {text} = req.body;
-      const result = await verifyVcb({text, getVerifyOptions});
+      // default to 'qr_code' if value is not included
+      const {text, type = BARCODE_FORMATS.QR_CODE} = req.body;
+      const result = await verifyVcb({text, type, getVerifyOptions});
       res.json(result);
     })];
   return function verifyVcbMiddleware(req, res, next) {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -14,9 +14,12 @@ export function createVerifyVcb({getVerifyOptions} = {}) {
   const mw = [
     validate({bodySchema: verifyBody}),
     asyncHandler(async (req, res) => {
-      // default to 'qr_code' if value is not included
-      const {text, type = BARCODE_FORMATS.QR_CODE} = req.body;
-      const result = await verifyVcb({text, type, getVerifyOptions});
+      const {text, barcode} = req.body;
+      const data = barcode?.data ?? text;
+      // default to 'qr_code' format if value is not included
+      const format = barcode?.format || BARCODE_FORMATS.QR_CODE;
+      // accept text or data and default format to qr_code
+      const result = await verifyVcb({data, format, getVerifyOptions});
       res.json(result);
     })];
   return function verifyVcbMiddleware(req, res, next) {

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -109,7 +109,7 @@ export async function verifyVcb({text, barcode, getVerifyOptions} = {}) {
     const verifyOptions = await getVerifyOptions({text});
     const {
       barcodeToCredential: getCredential = barcodeToCredential,
-      documentLoader,
+      documentLoader = _throwNotFoundError,
       verifyCredential
     } = verifyOptions;
     assert.func(getCredential);
@@ -140,4 +140,12 @@ function _checkExpiration({credential}) {
   const validUntil = new Date(credential.validUntil || '');
   const today = new Date();
   return validUntil < today;
+}
+
+function _throwNotFoundError(url) {
+  throw new BedrockError(`Document "${url}" not found`, {
+    name: 'NotFoundError',
+    details: {httpStatusCode: 404, public: true},
+    public: true
+  });
 }

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -7,7 +7,6 @@ import assert from 'assert-plus';
 import {BARCODE_FORMATS} from './constants.js';
 import {httpClient} from '@digitalbazaar/http-client';
 import {httpsAgent} from '@bedrock/https-agent';
-import {typeTableLoader} from './typeTableLoader.js';
 import {util} from '@digitalbazaar/vpqr';
 import {VC_CONTEXT_V2} from './constants.js';
 import {zcapClient} from './zcapClient.js';
@@ -18,11 +17,10 @@ export async function barcodeToCredential({
   text, barcode, documentLoader, typeTableLoader = _typeTableLoader,
 } = {}) {
   if(barcode && barcode.format !== BARCODE_FORMATS.QR_CODE) {
-    throw new BedrockError(
-      `Unsupported barcode format "${barcode.format}".`, {
-        name: 'NotSupportedError',
-        details: {httpStatusCode: 400, public: true}
-      });
+    throw new BedrockError(`Unsupported barcode format "${barcode.format}".`, {
+      name: 'NotSupportedError',
+      details: {httpStatusCode: 400, public: true}
+    });
   }
   text = barcode?.data ?? text;
   const {jsonldDocument: credential} = await util.fromQrCode({
@@ -40,15 +38,15 @@ export async function barcodeToEnvelopedCredential({text, barcode} = {}) {
     id: null,
     type: 'EnvelopedVerifiableCredential'
   };
-  if(text) {
+  if(text !== undefined) {
     barcode = {data: text, format: 'qr_code'};
   }
-  if(barcode.format === 'pdf417') {
-    credential.id = 'data:application/vcb;barcode=pdf417;base64,' +
+  const mediaType = `data:application/vcb;barcode=${barcode.format}`;
+  if(barcode.format === BARCODE_FORMATS.PDF417) {
+    credential.id = `${mediaType};base64,` +
       Buffer.from(barcode.data, 'utf8').toString('base64');
-  } else if(barcode.format === 'qr_code') {
-    credential.id = 'data:application/vcb;barcode=qr_code,' +
-      barcode.data;
+  } else if(barcode.format === BARCODE_FORMATS.QR_CODE) {
+    credential.id = `${mediaType},${barcode.data}`;
   } else {
     throw new BedrockError(
       'Could not create enveloped verifiable credential; ' +

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -39,7 +39,7 @@ export async function barcodeToEnvelopedCredential({text, barcode} = {}) {
     type: 'EnvelopedVerifiableCredential'
   };
   if(text !== undefined) {
-    barcode = {data: text, format: 'qr_code'};
+    barcode = {data: text, format: BARCODE_FORMATS.QR_CODE};
   }
   const mediaType = `data:application/vcb;barcode=${barcode.format}`;
   if(barcode.format === BARCODE_FORMATS.PDF417) {

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -4,8 +4,10 @@
 import * as bedrock from '@bedrock/core';
 import {typeTableLoader as _typeTableLoader} from './typeTableLoader.js';
 import assert from 'assert-plus';
+import {BARCODE_FORMATS} from './constants.js';
 import {httpClient} from '@digitalbazaar/http-client';
 import {httpsAgent} from '@bedrock/https-agent';
+import {typeTableLoader} from './typeTableLoader.js';
 import {util} from '@digitalbazaar/vpqr';
 import {VC_CONTEXT_V2} from './constants.js';
 import {zcapClient} from './zcapClient.js';
@@ -15,6 +17,13 @@ const {util: {BedrockError}} = bedrock;
 export async function barcodeToCredential({
   text, barcode, documentLoader, typeTableLoader = _typeTableLoader,
 } = {}) {
+  if(barcode && barcode.format !== BARCODE_FORMATS.QR_CODE) {
+    throw new BedrockError(
+      `Unsupported barcode format "${barcode.format}".`, {
+        name: 'NotSupportedError',
+        details: {httpStatusCode: 400, public: true}
+      });
+  }
   text = barcode?.data ?? text;
   const {jsonldDocument: credential} = await util.fromQrCode({
     text,
@@ -43,8 +52,8 @@ export async function barcodeToEnvelopedCredential({text, barcode} = {}) {
   } else {
     throw new BedrockError(
       'Could not create enveloped verifiable credential; ' +
-      `unknown barcode format "${barcode.format}".`, {
-        name: 'OperationError',
+      `unsupported barcode format "${barcode.format}".`, {
+        name: 'NotSupportedError',
         details: {httpStatusCode: 400, public: true}
       });
   }

--- a/schemas/bedrock-vcb-verifier.js
+++ b/schemas/bedrock-vcb-verifier.js
@@ -14,17 +14,18 @@ export const verifyBody = {
       properties: {
         data: {
           title: 'Data from barcode scan',
-          type: 'string',
+          type: 'string'
         },
         media_type: {
           title: 'Media type of the scanned barcode',
-          type: 'string',
+          type: 'string'
         },
         format: {
           title: 'Format of the scanned barcode',
           type: 'string',
           enum: [
-            // See https://wicg.github.io/shape-detection-api/#barcodeformat-section
+            // eslint-disable-next-line max-len
+            // see https://wicg.github.io/shape-detection-api/#barcodeformat-section
             'aztec',
             'code_128',
             'code_39',
@@ -38,15 +39,14 @@ export const verifyBody = {
             'qr_code',
             'unknown',
             'upc_a',
-            'upc_e',
+            'upc_e'
           ]
         }
       }
     },
-    // allow use of conneg w/non-JSON payload
     text: {
       title: 'Text encoding of a VCB',
-      type: 'string',
-    },
-  },
+      type: 'string'
+    }
+  }
 };

--- a/schemas/bedrock-vcb-verifier.js
+++ b/schemas/bedrock-vcb-verifier.js
@@ -39,9 +39,9 @@ export const verifyBody = {
             'unknown',
             'upc_a',
             'upc_e',
-          ],
-        },
-      },
+          ]
+        }
+      }
     },
     // allow use of conneg w/non-JSON payload
     text: {

--- a/schemas/bedrock-vcb-verifier.js
+++ b/schemas/bedrock-vcb-verifier.js
@@ -4,16 +4,34 @@
 export const verifyBody = {
   title: 'Verify VCB Request',
   type: 'object',
-  additionalProperties: false,
+  additionalProperties: true,
   required: ['text'],
   properties: {
-    // FIXME: pass media type and/or format/type in another property or
     // allow use of conneg w/non-JSON payload
     text: {
       title: 'Text encoding of a VCB',
       type: 'string',
-      // must start with `VC1-` header
-      pattern: '^VC1-'
-    }
-  }
+    },
+    type: {
+      title: 'Type of scanned barcode',
+      type: 'string',
+      enum: [
+        // See https://wicg.github.io/shape-detection-api/#barcodeformat-section
+        'aztec',
+        'code_128',
+        'code_39',
+        'code_93',
+        'codabar',
+        'data_matrix',
+        'ean_13',
+        'ean_8',
+        'itf',
+        'pdf417',
+        'qr_code',
+        'unknown',
+        'upc_a',
+        'upc_e'
+      ]
+    },
+  },
 };

--- a/schemas/bedrock-vcb-verifier.js
+++ b/schemas/bedrock-vcb-verifier.js
@@ -5,33 +5,48 @@ export const verifyBody = {
   title: 'Verify VCB Request',
   type: 'object',
   additionalProperties: true,
-  required: ['text'],
   properties: {
+    barcode: {
+      title: 'Scanned barcode information',
+      type: 'object',
+      additionalProperties: false,
+      required: ['data', 'format'],
+      properties: {
+        data: {
+          title: 'Data from barcode scan',
+          type: 'string',
+        },
+        media_type: {
+          title: 'Media type of the scanned barcode',
+          type: 'string',
+        },
+        format: {
+          title: 'Format of the scanned barcode',
+          type: 'string',
+          enum: [
+            // See https://wicg.github.io/shape-detection-api/#barcodeformat-section
+            'aztec',
+            'code_128',
+            'code_39',
+            'code_93',
+            'codabar',
+            'data_matrix',
+            'ean_13',
+            'ean_8',
+            'itf',
+            'pdf417',
+            'qr_code',
+            'unknown',
+            'upc_a',
+            'upc_e',
+          ],
+        },
+      },
+    },
     // allow use of conneg w/non-JSON payload
     text: {
       title: 'Text encoding of a VCB',
       type: 'string',
-    },
-    type: {
-      title: 'Type of scanned barcode',
-      type: 'string',
-      enum: [
-        // See https://wicg.github.io/shape-detection-api/#barcodeformat-section
-        'aztec',
-        'code_128',
-        'code_39',
-        'code_93',
-        'codabar',
-        'data_matrix',
-        'ean_13',
-        'ean_8',
-        'itf',
-        'pdf417',
-        'qr_code',
-        'unknown',
-        'upc_a',
-        'upc_e'
-      ]
     },
   },
 };

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -15,13 +15,36 @@ describe('http API', () => {
       url = `${bedrock.config.server.baseUri}${target}`;
     });
 
-    it('verifies VCB text transformed to an enveloped VC', async () => {
+    it('verifies VCB "text" transformed to an enveloped VC', async () => {
       let err;
       let result;
       try {
         const response = await httpClient.post(url, {
           agent: httpsAgent,
           json: {text: mockData.vcbText}
+        });
+        result = response.data;
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.include.keys(['credential', 'verified', 'expired']);
+      result.verified.should.equal(true);
+    });
+
+    it('verifies VCB "barcode" transformed to an enveloped VC', async () => {
+      let err;
+      let result;
+      try {
+        const response = await httpClient.post(url, {
+          agent: httpsAgent,
+          json: {
+            barcode: {
+              data: mockData.vcbText,
+              format: 'qr_code'
+            }
+          }
         });
         result = response.data;
       } catch(e) {
@@ -41,7 +64,7 @@ describe('http API', () => {
       url = `${bedrock.config.server.baseUri}${target}`;
     });
 
-    it('verifies VCB text locally converted from CBOR-LD', async () => {
+    it('verifies VCB "text" locally converted from CBOR-LD', async () => {
       let err;
       let result;
       try {

--- a/test/test.js
+++ b/test/test.js
@@ -77,7 +77,6 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
         return {
           // use preferred `barcodeToEnvelopedCredential` method
           barcodeToCredential: barcodeToEnvelopedCredential,
-          documentLoader,
           async verifyCredential({credential}) {
             return verify({credential, capability});
           }

--- a/test/test.js
+++ b/test/test.js
@@ -160,7 +160,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
         }
         const barcode = {
           data: contents,
-          type: format.parameters.get('barcode') ?? 'qr_code'
+          format: format.parameters.get('barcode') ?? 'qr_code'
         };
         if(format.parameters.has('base64')) {
           barcode.data = new Uint8Array(Buffer.from(contents, 'base64'));


### PR DESCRIPTION
#### _Resolves - add barcode to acceptable payload_

---

### What kind of change does this PR introduce?

- Feature update

<br/>

### What is the current behavior?

- Only accepts qr code text

<br/>

### What is the new behavior?

- Allows user to specify the type of barcode scanned

Example
```json
{
  "barcode": {
    "data": "asdlkfj;asldjfl;asdjfalsdjfsdf...",
    "format": "qr_code"
  }
}
```

<br/>

### Does this PR introduce a breaking change?

- No

<br/>

### How has this been tested?

- Locally by including a barcode object

<br/>

### Screenshots:

- n/a