### PR TITLE
Return credential from exchange in result.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vcb-verifier ChangeLog
 
+## 1.3.1 - 2025-04-xx
+
+### Fixed
+- Return the unenveloped `credential` in the result returned from `verify()`.
+
 ## 1.3.0 - 2025-04-14
 
 ### Added

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -153,6 +153,7 @@ export async function verify({
         // update `credential`
         const {getCredentialFromExchange} = options;
         credential = await getCredentialFromExchange({exchange, credential});
+        result.credential = credential;
       }
     } catch(cause) {
       throw new BedrockError(


### PR DESCRIPTION
#### _Resolves - bug fix_

---

### What kind of change does this PR introduce?

- Bug fix

<br/>

### What is the current behavior?

- Credential extracted from enveloped credential is not returned

<br/>

### What is the new behavior?

- Return the credential that is extracted from the enveloped credential

<br/>

### Does this PR introduce a breaking change?

- No

<br/>

### How has this been tested?

- Locally

<br/>

### Screenshots:

- n/a