### PR TITLE
Return credential in results when verification error occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # bedrock-vcb-verifier ChangeLog
 
-## 1.3.4 - 2025-05-xx
+## 1.4.0 - 2025-05-dd
 
-### Changed
+### Added
 - Return credential in results when verification error occurs.
 
 ## 1.3.3 - 2025-05-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vcb-verifier ChangeLog
 
+## 1.3.4 - 2025-05-xx
+
+### Changed
+- Return credential in results when verification error occurs.
+
 ## 1.3.3 - 2025-05-12
 
 ### Changed

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -164,6 +164,12 @@ export async function verify({
     }
   }
 
+  // get credential from error's credentialResults if not present in result
+  if(result.error && !result.credential) {
+    credential = result?.error?.details?.credentialResults?.[0]?.credential;
+    result.credential = credential;
+  }
+
   if(checkExpiration) {
     result.expired = isExpired({credential, maxClockSkew});
   }


### PR DESCRIPTION
#### _Resolves - return credential in results when verification error occurs_

---

### What kind of change does this PR introduce?

- Error handling update

<br/>

### What is the current behavior?

- result.credential field is undefined when error occurs in verification (e.g., expired credential)

<br/>

### What is the new behavior?

- result.credential field is populated with `result.error.details.credentialResults[0].credential`

<br/>

### Does this PR introduce a breaking change?

- No

<br/>

### How has this been tested?

- Locally with a verifier coordinator

<br/>

### Screenshots:

- n/a